### PR TITLE
Add content type to youtube.js

### DIFF
--- a/videos/src/apis/youtube.js
+++ b/videos/src/apis/youtube.js
@@ -7,6 +7,7 @@ export default axios.create({
   params: {
     part: 'snippet',
     maxResults: 5,
+    type: 'video',
     key: KEY
   }
 });


### PR DESCRIPTION
Setting type to video makes the API only fetch videos and not channels or playlists.