### PR TITLE
fix: empty user input

### DIFF
--- a/widgets/src/components/Search.js
+++ b/widgets/src/components/Search.js
@@ -17,20 +17,23 @@ const Search = () => {
   }, [term]);
 
   useEffect(() => {
-    const search = async () => {
-      const { data } = await axios.get('https://en.wikipedia.org/w/api.php', {
-        params: {
-          action: 'query',
-          list: 'search',
-          origin: '*',
-          format: 'json',
-          srsearch: debouncedTerm,
-        },
-      });
+    if(debouncedTerm === 'programming' || debouncedTerm.length > 0) { //perform initial search but not to search when user input is empty!
+    
+      const search = async () => {
+        const { data } = await axios.get('https://en.wikipedia.org/w/api.php', {
+          params: {
+            action: 'query',
+            list: 'search',
+            origin: '*',
+            format: 'json',
+            srsearch: debouncedTerm,
+          },
+        });
 
-      setResults(data.query.search);
-    };
-    search();
+        setResults(data.query.search);
+      };
+      search();
+    }
   }, [debouncedTerm]);
 
   const renderedResults = results.map((result) => {


### PR DESCRIPTION
It will perform initial search with the default term, however whenever a user provides empty input, no search will be initiated.